### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Upload coverage information
         run: |
           GIT_BRANCH="${GITHUB_HEAD_REF}" ./cc-test-reporter after-build -p github.com/streamdal/go-sdk -r ${{ secrets.CC_TEST_REPORTER_ID }}
+          rm ./cc-test-reporter
       - name: Generate new tag (dry run)
         uses: mathieudutour/github-tag-action@v6.1
         id: get_new_version

--- a/go_sdk.go
+++ b/go_sdk.go
@@ -624,22 +624,9 @@ func (s *Streamdal) Process(ctx context.Context, req *ProcessRequest) (*ProcessR
 					}, nil
 				}
 			case protos.WASMExitCode_WASM_EXIT_CODE_FAILURE:
-				s.config.Logger.Errorf("Step '%s' returned exit code failure", step.Name)
-
-				_ = s.metrics.Incr(ctx, &types.CounterEntry{Name: counterError, Labels: labels, Value: 1, Audience: aud})
-
-				shouldContinue := s.handleConditions(ctx, step.OnFailure, pipeline, step, aud, req)
-				if !shouldContinue {
-					timeoutCxl()
-					s.sendTail(aud, pipeline.Id, originalData, wasmResp.OutputPayload)
-					return &ProcessResponse{
-						Data:    wasmResp.OutputPayload,
-						Error:   true,
-						Message: "detective step failed", // TODO: WASM module should return the error message, not just "detective run completed"
-					}, nil
-				}
+				fallthrough
 			case protos.WASMExitCode_WASM_EXIT_CODE_INTERNAL_ERROR:
-				s.config.Logger.Errorf("Step '%s' returned exit code internal error", step.Name)
+				s.config.Logger.Errorf("Step '%s' returned exit code '%s'", step.Name, wasmResp.ExitCode.String())
 
 				_ = s.metrics.Incr(ctx, &types.CounterEntry{Name: counterError, Labels: labels, Value: 1, Audience: aud})
 
@@ -650,7 +637,7 @@ func (s *Streamdal) Process(ctx context.Context, req *ProcessRequest) (*ProcessR
 					return &ProcessResponse{
 						Data:    wasmResp.OutputPayload,
 						Error:   true,
-						Message: "detective step failed:" + wasmResp.ExitMsg,
+						Message: "step failed:" + wasmResp.ExitMsg,
 					}, nil
 				}
 			default:
@@ -730,12 +717,4 @@ func (a *Audience) ToProto(serviceName string) *protos.Audience {
 		OperationType: protos.OperationType(a.OperationType),
 		OperationName: a.OperationName,
 	}
-}
-
-func stringPtr(in string) *string {
-	return &in
-}
-
-func boolPtr(in bool) *bool {
-	return &in
 }

--- a/go_sdk.go
+++ b/go_sdk.go
@@ -637,7 +637,7 @@ func (s *Streamdal) Process(ctx context.Context, req *ProcessRequest) (*ProcessR
 					return &ProcessResponse{
 						Data:    wasmResp.OutputPayload,
 						Error:   true,
-						Message: "step failed:" + wasmResp.ExitMsg,
+						Message: "step failed: " + wasmResp.ExitMsg,
 					}, nil
 				}
 			default:

--- a/go_sdk_test.go
+++ b/go_sdk_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Streamdal", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.Error).To(BeTrue())
-			Expect(resp.Message).To(Equal("detective step failed"))
+			Expect(resp.Message).To(ContainSubstring("step failed"))
 		})
 	})
 })

--- a/go_sdk_test.go
+++ b/go_sdk_test.go
@@ -732,3 +732,11 @@ func TestInferSchema(t *testing.T) {
 		t.Errorf("expected ExitMsg to contain 'inferred fresh schema', got = %s", wasmResp.ExitMsg)
 	}
 }
+
+func stringPtr(in string) *string {
+	return &in
+}
+
+func boolPtr(in bool) *bool {
+	return &in
+}


### PR DESCRIPTION
* Remove cc-test-reporter binary from git and prevent it from being committed during auto-tag
* Moving pointer helper functions to test file
* Removing code duplication on wasm failure select cases