### PR TITLE
Fix counter label concurrency issue

### DIFF
--- a/go_sdk_test.go
+++ b/go_sdk_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Streamdal", func() {
 
 	Context("New", func() {
 		It("returns a new instance of Streamdal", func() {
-			lis, err := net.Listen("tcp", ":8082")
+			lis, err := net.Listen("tcp", ":18082")
 			Expect(err).ToNot(HaveOccurred())
 
 			srv := grpc.NewServer()
@@ -135,7 +135,7 @@ var _ = Describe("Streamdal", func() {
 			cfg := &Config{
 				ServiceName: "mysvc1",
 				ShutdownCtx: ctx,
-				ServerURL:   "localhost:8082",
+				ServerURL:   "localhost:18082",
 				ServerToken: "foo",
 				DryRun:      false,
 				Logger:      &loggerfakes.FakeLogger{},


### PR DESCRIPTION
`labels` had a chance to be reused after it was already passed along to the metrics service where it would be read by the counter worker. Fixed by making a fresh map for each call to Incr()