### PR TITLE
Fix init_wasm.sh

### DIFF
--- a/init_wasm.sh
+++ b/init_wasm.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+mkdir -p test-assets/wasm
+
 # Step 1: Curl the GitHub API to get the latest release
-latest_release=$(curl -s https://api.github.com/repos/streamdal/streamdal/releases/latest)
+latest_release=$(curl -s https://api.github.com/repos/streamdal/streamdal/releases)
 
 # Step 2: Extract the "browser_download_url" from the JSON response
-download_url=$(echo "$latest_release" | grep -o 'https://.*\.zip')
+download_url=$(echo "$latest_release" | grep -o 'https://.*/libs/wasm/.*/release\.zip' | head -1)
 
 # Step 3: Add debug info
 mkdir -p test-assets/wasm


### PR DESCRIPTION
Github's `/latest` endpoint isn't returning the libs/wasm release anymore for some reason. This uses the main releases endpoint and grabs the latest .zip from `libs/wasm`